### PR TITLE
Adding in progress builds and UniProtKB link

### DIFF
--- a/src/main/resources/static/ptmexchange/index.html
+++ b/src/main/resources/static/ptmexchange/index.html
@@ -25,16 +25,16 @@
     <h1>Datasets</h1>
     <table class="pcdatatable" style="border-collapse:collapse;">
       <tr>
-	<th>Species</th><th>Name</th><th>Modification</th><th>PXD</th><th>PeptideAtlas</th><th>UniProtKB</th><th>Publication</th><th>Summary Results</th><th>Search Database</th>
+	<th>Species</th><th>Name</th><th>Modification</th><th>PXD</th><th>PeptideAtlas</th><th>UniProtKB*</th><th>Publication</th><th>Summary Results</th><th>Search Database</th>
       </tr>
       <tr class="pc-hov">
-        <td><i>Oryza sativa</i></td><td>Rice</td><td>Phospho</td><td><a href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD046188">PXD046188</a></td><td><a href="https://peptideatlas.org/builds/rice/phospho/">Rice Phospho 2022&#8209;11</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000059680">Oryza sativa subsp. japonica (Rice) proteome</a></td><td><a href="https://pubs.acs.org/doi/10.1021/acs.jproteome.4c00187">Ramsbottom et al., 2024</a></td><td><a href="./Files/Rice_GSB_phospho_all_prots_0924.csv.gz">  Results</a></td><td><a href="./Files/Osativa_super_annotation_union_noIC4R_v2_cRAP.fasta.gz"> Fasta file</a></td>
+        <td><i>Oryza sativa</i></td><td>Rice</td><td>Phospho</td><td><a href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD046188">PXD046188</a></td><td><a href="https://peptideatlas.org/builds/rice/phospho/">Rice Phospho 2022&#8209;04</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000059680">Oryza sativa subsp. japonica (Rice) proteome</a></td><td><a href="https://pubs.acs.org/doi/10.1021/acs.jproteome.4c00187">Ramsbottom et al., 2024</a></td><td><a href="./Files/Rice_GSB_phospho_all_prots_0924.csv.gz">  Results</a></td><td><a href="./Files/Osativa_super_annotation_union_noIC4R_v2_cRAP.fasta.gz"> Fasta file</a></td>
       </tr>
       <tr class="pc-hov">
         <td><i>Plasmodium falciparum</i></td><td>Malaria parasite</td><td>Phospho</td><td><a href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD046874">PXD046874</a></td><td><a href="https://peptideatlas.org/builds/pfalciparum/phospho/">Plasmodium Phospho 2023&#8209;10</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000001450">Plasmodium falciparum (isolate 3D7) proteome</a></td><td><a href="https://pubs.acs.org/doi/10.1021/acs.jproteome.4c00418">Camacho et al., 2024</a></td><td><a href="./Files/Pf_GSB_phospho_all_prots_no_human_0924.csv.gz">  Results</a></td><td><a href="./Files/PlasmoDB-51_Pfalciparum3D7_AnnotatedProteins_cRAP_PA_THISP_Level1_2020-09-01_target_decoy.fasta.gz"> Fasta file</a></td>
       </tr>
       <tr class="pc-hov">
-        <td><i>Mus musculus</i></td><td>Mouse</td><td>Phospho</td><td>N/A</td><td><a href="https://peptideatlas.org/builds/mouse/phospho/">Mouse Phospho 2022&#8209;11</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000000589">Mus musculus (Mouse) proteome</a></td><td></td><td><a href="./Files/Mouse_GSB_phospo_all_prots_0125.csv.gz">  Results</a></td><td><a href="./Files/Mm_UP000000589-GCF_000001635.27-ENS105_cRAP_decoy.fasta.gz"> Fasta file</a></td>
+        <td><i>Mus musculus</i></td><td>Mouse</td><td>Phospho</td><td>N/A</td><td><a href="https://peptideatlas.org/builds/mouse/phospho/">Mouse Phospho 2024&#8209;02</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000000589">Mus musculus (Mouse) proteome</a></td><td></td><td><a href="./Files/Mouse_GSB_phospo_all_prots_0125.csv.gz">  Results</a></td><td><a href="./Files/Mm_UP000000589-GCF_000001635.27-ENS105_cRAP_decoy.fasta.gz"> Fasta file</a></td>
       </tr>
       <tr class="pc-hov">
         <td><i>Saccharomyces cerevisiae</i></td><td>Yeast</td><td>Phospho</td><td><a href="https://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD071918">PXD071918</a></td><td><a href="https://peptideatlas.org/builds/yeast/phospho/">Yeast Phospho 2024&#8209;08</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000002311">Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast) proteome</a></td><td></td><td><a href="./Files/Yeast_GSB_phospho_all_prots_0125.csv.gz">  Results</a></td><td> <a href="./Files/2023-11-27-decoys-contam-uniprotkb_proteome_UP000002311_2023_11_27.fasta.gz"> Fasta file</a></td>
@@ -49,23 +49,24 @@
         <td><i>Homo sapiens</i></td><td>Human</td><td>Phospho</td><td>N/A</td><td><a href="https://peptideatlas.org/builds/human/phospho/">Human Phospho 2025&#8209;12</td><td>In progress</td><td></td><td></td><td></td>
       </tr>
 	  <tr class="pc-hov">
-        <td><i>Homo sapiens</i></td><td>Human</td><td>SUMO</td><td><a href="https://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD068489">PXD068489</a></td><td><a href="https://peptideatlas.org/builds/human/sumo/">Human SUMO 2025&#8209;02</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000005640">Homo sapiens (Human) proteome<a/></td><td></td><td><a href="./Files/Human_GSB_SUMO_all_prots_0924.csv.gz">  Results</a></td><td><a href="./Files/Homo_one_Prot_per_Gene_cRAB_decoy.fasta.gz"> Fasta file</a></td>
+        <td><i>Homo sapiens</i></td><td>Human</td><td>SUMO</td><td><a href="https://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD068489">PXD068489</a></td><td><a href="https://peptideatlas.org/builds/human/sumo/">Human SUMO 2025&#8209;02</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000005640">Homo sapiens (Human) proteome</a></td><td></td><td><a href="./Files/Human_GSB_SUMO_all_prots_0924.csv.gz">  Results</a></td><td><a href="./Files/Homo_one_Prot_per_Gene_cRAB_decoy.fasta.gz"> Fasta file</a></td>
       </tr>
 	  <tr class="pc-hov">
-        <td><i>Homo sapiens</i></td><td>Human</td><td>Ubiquitination</td><td>N/A</td><td><a href="https://peptideatlas.org/builds/human/ubiquitination/">Human Ubiquitination 2025-??</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000005640">Homo sapiens (Human) proteome<a/></td><td></td><td><a href="./Files/Human_GSB_Ubiq_all_prots_1106.csv.gz">  Results</a></td><td><a href="./Files/2024-04-04-decoys-contam-uniprotkb_proteome_UP000005640.fasta.gz"> Fasta file</a></td>
+        <td><i>Homo sapiens</i></td><td>Human</td><td>Ubiquitination</td><td>N/A</td><td>In progress</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000005640">Homo sapiens (Human) proteome</a></td><td></td><td><a href="./Files/Human_GSB_Ubiq_all_prots_1106.csv.gz">  Results</a></td><td><a href="./Files/2024-04-04-decoys-contam-uniprotkb_proteome_UP000005640.fasta.gz"> Fasta file</a></td>
       </tr>
 	  <tr class="pc-hov">
-        <td><i>Homo sapiens</i></td><td>Human</td><td>Acetylation</td><td>N/A</td><td><a href="https://peptideatlas.org/builds/human/acetylation/">Human Acetylation 2025-??</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000005640">Homo sapiens (Human) proteome<a/></td><td></td><td><a href="./Files/Human_GSB_Acetyl_all_prots_1106.csv.gz">  Results</a></td><td><a href="./Files/2024-04-04-decoys-contam-uniprotkb_proteome_UP000005640.fasta.gz"> Fasta file</a></td>
+        <td><i>Homo sapiens</i></td><td>Human</td><td>Acetylation</td><td>N/A</td><td>In progress</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000005640">Homo sapiens (Human) proteome</a></td><td></td><td><a href="./Files/Human_GSB_Acetyl_all_prots_1106.csv.gz">  Results</a></td><td><a href="./Files/2024-04-04-decoys-contam-uniprotkb_proteome_UP000005640.fasta.gz"> Fasta file</a></td>
       </tr>
 	  <tr class="pc-hov">
-        <td><i>Toxoplasma gondii</i></td><td>Infectious agent of toxoplasmosis</td><td>Phospho</td><td>N/A</td><td><a href="https://peptideatlas.org/builds/toxo/phospho/">T. gondii Phospho 2025&#8209;05</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000001529">Toxoplasma gondii (strain ATCC 50611 / Me49) proteome<a/></td><td></td><td><a href="./Files/Tgondii_GSB_phospho_all_prots_0226.csv.gz">  Results</a></td><td><a href="./Files/2024-10-24-decoys-contam-merged_database.fasta.gz"> Fasta file</a></td>
+        <td><i>Toxoplasma gondii</i></td><td>Infectious agent of toxoplasmosis</td><td>Phospho</td><td>N/A</td><td><a href="https://peptideatlas.org/builds/toxo/phospho/">T. gondii Phospho 2025&#8209;05</td><td>Visible on <a href="https://www.uniprot.org/proteomes/UP000001529">Toxoplasma gondii (strain ATCC 50611 / Me49) proteome</a></td><td></td><td><a href="./Files/Tgondii_GSB_phospho_all_prots_0226.csv.gz">  Results</a></td><td><a href="./Files/2024-10-24-decoys-contam-merged_database.fasta.gz"> Fasta file</a></td>
       </tr>
     </table>
+	<p>*For access on UniProtKB, please follow this <a href="https://www.uniprot.org/help/mod_res_large_scale">guide</a>.</p>
     <br>
 
     <h2>PTM Builds in Progress</h2>
     <ul>
-      <li>To be updated.</li>
+      <li>Phosphorylation in <i>Arabidopsis thaliana</i></li>
     </ul>
  </div></div>
 


### PR DESCRIPTION
Updating the in progress builds section.
Adding a link explaining how to access the data in UniProtKB.
Removing PeptideAtlas links which are not currently live.
Updating PeptideAtlas dates/versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed phosphorylation and PTM dataset information with updated builds and proteome links
  * Updated PTM builds in progress list with new entries
  * Added guidance for accessing datasets on UniProtKB

<!-- end of auto-generated comment: release notes by coderabbit.ai -->